### PR TITLE
Add Lint checks for Compose

### DIFF
--- a/.github/workflows/pr_steps.yml
+++ b/.github/workflows/pr_steps.yml
@@ -24,4 +24,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v4.1.0
 
       - name: Build with Gradle
-        run: ./gradlew detekt assembleRelease testRelease
+        run: ./gradlew detekt lintRelease assembleRelease testRelease

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,4 +56,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    lintChecks(libs.compose.lint.checks)
 }

--- a/app/src/main/java/blog/tsalikis/kotlin/android/MainActivity.kt
+++ b/app/src/main/java/blog/tsalikis/kotlin/android/MainActivity.kt
@@ -40,7 +40,7 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+private fun GreetingPreview() {
     KotlinandroidtemplateTheme {
         Greeting("Android")
     }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -740,6 +740,7 @@ style:
   UnusedPrivateMember:
     active: true
     allowedNames: ''
+    ignoreAnnotated: ['Preview']
   UnusedPrivateProperty:
     active: true
     allowedNames: '_|ignored|expected|serialVersionUID'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.8.0"
+composeLintChecks = "1.4.2"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -12,6 +13,7 @@ detekt = "1.23.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+compose-lint-checks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request 🙌 -->

## 🚀 Description
Add Lint checks for Compose to resolve common Compose issues

## ✅ Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## 🎯 Motivation and Context
Adopting Compose can be challenging for new teams. Adding static analysis for Compose through Lint checks will allow to easily mitigate known common issues that arise with the adoption of Compose.

The [compose-lints](https://slackhq.github.io/compose-lints/) library is a quick way to incorporate these static checks that are specific for Compose.

## 🔍 How Has This Been Tested?
Manually that the project builds.

## 📎 Additional resources (if applicable):
N/A
