### PR TITLE
Add name for build step on the Pull Request Workflow

### DIFF
--- a/.github/workflows/pr_steps.yml
+++ b/.github/workflows/pr_steps.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Run static checks and build
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request 🙌 -->

## 🚀 Description
Override the default name of the `build` step on the `pr_steps.yml`.

## ✅ Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## 🎯 Motivation and Context
In order to require status checks to pass for a PR we need to add a name property under `job`, not to be confused with the `name` property at the top level of the `pr_steps.yml`. Otherwise, the default name is `build`.

## 🔍 How Has This Been Tested?
Manually that the new name is available on the repository's `Require status checks to pass before merging ` setting.

## 📎 Additional resources (if applicable):
N/A
